### PR TITLE
Updating html-angular-validate version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 html-angular-validate-report.json
+html-angular-validate-report-checkstyle.json

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/ewu02/gulp-html-angular-validate#readme",
   "dependencies": {
     "gulp-util": "^3.0.6",
-    "html-angular-validate": "~0.1.4",
+    "html-angular-validate": "~0.1.5",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I published a new version of html-angular-validate, so here's a pull request updating your version.

New:
-   Deep copy of passed in options
-   Support for outputting a checkstyle XML report
